### PR TITLE
Add dotenv config support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Sample environment configuration for ai-bug-triage-agent
+# Copy this file to .env and fill in the values for your environment
+
+# Jira settings
+JIRA_URL=
+JIRA_USER=
+JIRA_TOKEN=
+JIRA_PROJECT=
+
+# Version control settings
+# Set VCS_TYPE to "git" for GitHub or "p4" for Perforce
+VCS_TYPE=git
+
+# GitHub settings
+GITHUB_REPO=
+GITHUB_TOKEN=
+
+# Perforce settings
+P4PORT=
+P4USER=
+P4TICKET=
+
+# Terraform settings
+TERRAFORM_DIR=

--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ This project provides a skeleton implementation for an AI-driven bug triage agen
 
 ## Running the Agent
 
-Set the following environment variables as needed:
+Configuration is handled via environment variables.  Copy `.env.example` to
+`.env` and fill in the appropriate values:
+
+```
+cp .env.example .env
+# edit .env with your editor of choice
+```
+
+The variables include:
 
 - `JIRA_URL`, `JIRA_USER`, `JIRA_TOKEN`, `JIRA_PROJECT` – Jira connection details.
 - `VCS_TYPE` – `git` for GitHub (default) or `p4` for Perforce.
@@ -21,7 +29,7 @@ Set the following environment variables as needed:
   directory containing your Terraform configuration.
 
 
-Run the agent with:
+Run the agent and the variables in `.env` will be loaded automatically:
 
 ```bash
 python -m ai_agent

--- a/ai_agent/__main__.py
+++ b/ai_agent/__main__.py
@@ -1,4 +1,5 @@
 import os
+from dotenv import load_dotenv
 from .connectors.jira import JiraConnector
 from .connectors.perforce import PerforceConnector
 from .connectors.github import GitHubConnector
@@ -9,6 +10,7 @@ from .terraform_infra import TerraformInfrastructure
 
 
 def main():
+    load_dotenv()
     jira_url = os.environ.get("JIRA_URL")
     jira_user = os.environ.get("JIRA_USER")
     jira_token = os.environ.get("JIRA_TOKEN")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 
 boto3
+python-dotenv


### PR DESCRIPTION
## Summary
- add `.env.example` template for environment variables
- load `.env` via `dotenv` in app startup
- mention how to use `.env` in README
- add `python-dotenv` requirement

## Testing
- `pip install -r requirements.txt`
- `python -m ai_agent` *(fails: JIRA_URL, JIRA_USER, JIRA_TOKEN and JIRA_PROJECT must be set)*


------
https://chatgpt.com/codex/tasks/task_e_6848dcf440b4832688ccd2a0bad3a62b