### PR TITLE
Add Dockerfile to spin up Perforce server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,18 @@ Infrastructure is created with Terraform using the
 configuration files. The helper will run `terraform init` and `terraform apply
 -auto-approve` prior to running the agent.
 
+## Running a Local Perforce Server with Docker
+
+A simple Dockerfile is provided in `docker/perforce` for running a Perforce (p4d) server. Build the image and start the container to expose the server on port `1666`:
+
+```bash
+docker build -t p4d-server docker/perforce
+
+docker run -d --name p4d -p 1666:1666 p4d-server
+```
+
+The container downloads the `p4d` binary from Perforce. If the download fails, ensure the URL in the Dockerfile matches an available release or update `P4D_VERSION` to the desired version.
+
 ## Notes
 This codebase provides a starting point only. Actual integration with Jira, Perforce, GitHub, and AWS requires additional configuration and authentication setup. The code analysis and learning components are simplified placeholders.
+

--- a/docker/perforce/Dockerfile
+++ b/docker/perforce/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04
+
+ENV P4PORT=1666 \
+    P4D_VERSION=r23.2 \
+    P4ROOT=/opt/perforce
+
+RUN apt-get update \
+    && apt-get install -y wget ca-certificates \
+    && mkdir -p ${P4ROOT} \
+    && useradd -m perforce \
+    && chown perforce:perforce ${P4ROOT}
+
+RUN wget -q https://cdist2.perforce.com/perforce/${P4D_VERSION}/bin.linux26x86_64/p4d -O /usr/local/bin/p4d \
+    || (echo "Failed to download p4d. Ensure the URL is correct and accessible." && exit 1) \
+    && chmod +x /usr/local/bin/p4d
+
+USER perforce
+WORKDIR ${P4ROOT}
+EXPOSE ${P4PORT}
+
+CMD ["p4d", "-r", "/opt/perforce", "-p", "1666", "-d", "--foreground"]


### PR DESCRIPTION
## Summary
- provide a Dockerfile for running a Perforce `p4d` server
- document how to build and run the Perforce server using Docker

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848e64c4a5c832686ada2d108873c34