### PR TITLE
Add default Perforce admin account setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ docker build -t p4d-server docker/perforce
 docker run -d --name p4d -p 1666:1666 p4d-server
 ```
 
+When the container starts for the first time it creates a default super user
+named `admin` with password `admin`. Use these credentials to log in and set up
+additional users or change the password:
+
+```bash
+p4 -p localhost:1666 -u admin login
+```
+
 The container downloads the `p4d` binary from Perforce. If the download fails, ensure the URL in the Dockerfile matches an available release or update `P4D_VERSION` to the desired version.
 
 ## Notes

--- a/docker/perforce/Dockerfile
+++ b/docker/perforce/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:22.04
 
 ENV P4PORT=1666 \
     P4D_VERSION=r23.2 \
-    P4ROOT=/opt/perforce
+    P4ROOT=/opt/perforce \
+    P4USER=admin \
+    P4PASS=admin
 
 RUN apt-get update \
     && apt-get install -y wget ca-certificates \
@@ -11,11 +13,16 @@ RUN apt-get update \
     && chown perforce:perforce ${P4ROOT}
 
 RUN wget -q https://cdist2.perforce.com/perforce/${P4D_VERSION}/bin.linux26x86_64/p4d -O /usr/local/bin/p4d \
-    || (echo "Failed to download p4d. Ensure the URL is correct and accessible." && exit 1) \
-    && chmod +x /usr/local/bin/p4d
+    && wget -q https://cdist2.perforce.com/perforce/${P4D_VERSION}/bin.linux26x86_64/p4 -O /usr/local/bin/p4 \
+    || (echo "Failed to download p4 binaries. Ensure the URL is correct and accessible." && exit 1) \
+    && chmod +x /usr/local/bin/p4d /usr/local/bin/p4
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 USER perforce
 WORKDIR ${P4ROOT}
 EXPOSE ${P4PORT}
 
-CMD ["p4d", "-r", "/opt/perforce", "-p", "1666", "-d", "--foreground"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD []

--- a/docker/perforce/entrypoint.sh
+++ b/docker/perforce/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Start p4d temporarily to create admin user if db is empty
+if [ ! -f "$P4ROOT/db.have" ]; then
+    p4d -r "$P4ROOT" -p "$P4PORT" -d
+    sleep 3
+    if ! /usr/local/bin/p4 -p localhost:$P4PORT users | grep -q "^$P4USER "; then
+        /usr/local/bin/p4 -p localhost:$P4PORT user -f -i <<P4EOF
+User: $P4USER
+Type: super
+Email: admin@example.com
+FullName: Administrator
+P4EOF
+        echo -e "$P4PASS\n$P4PASS" | /usr/local/bin/p4 -p localhost:$P4PORT passwd $P4USER
+    fi
+    /usr/local/bin/p4 -p localhost:$P4PORT admin stop
+fi
+
+exec p4d -r "$P4ROOT" -p "$P4PORT" -d --foreground


### PR DESCRIPTION
## Summary
- create an entrypoint for the Perforce docker container that initializes a default admin user
- update the Perforce Dockerfile to install `p4` client, set default credentials and use the entrypoint
- document the default admin credentials in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848e8ef897483269bc89423e20d2e9c