### PR TITLE
Add Perforce infrastructure setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ configuration files. The helper will run `terraform init` and `terraform apply
 
 ## Running a Local Perforce Server with Docker
 
-A simple Dockerfile is provided in `docker/perforce` for running a Perforce (p4d) server. Build the image and start the container to expose the server on port `1666`:
+A Docker Compose setup is provided in `infrastructure/Perforce` for running a
+Perforce (p4d) server. Start the service to expose the server on port `1666`:
 
 ```bash
-docker build -t p4d-server docker/perforce
-
-docker run -d --name p4d -p 1666:1666 p4d-server
+docker compose -f infrastructure/Perforce/docker-compose.yml up --build -d
 ```
 
 When the container starts for the first time it creates a default super user

--- a/infrastructure/Perforce/Dockerfile
+++ b/infrastructure/Perforce/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04
+
+# Set environment variables
+ENV P4PORT=1666 \
+    P4USER=admin \
+    P4PASSWD=Passw0rd123! \
+    P4ROOT=/perforce-data \
+    P4DEPOTS=/perforce-data/depots \
+    DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    wget \
+    gnupg \
+ && rm -rf /var/lib/apt/lists/*
+
+# Add Perforce package repository
+RUN wget -q https://package.perforce.com/perforce.pubkey -O /tmp/perforce.pubkey && \
+    apt-key add /tmp/perforce.pubkey && \
+    echo "deb http://package.perforce.com/apt/ubuntu focal release" > /etc/apt/sources.list.d/perforce.list && \
+    apt-get update
+
+# Install Helix Core (P4D)
+RUN apt-get install -y helix-p4d
+
+# Create Perforce data directory
+RUN mkdir -p $P4ROOT $P4DEPOTS
+
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Expose Perforce port
+EXPOSE 1666
+
+# Set volumes for persistent storage
+VOLUME ["/perforce-data"]
+
+# Entrypoint to initialize and start P4D
+ENTRYPOINT ["/entrypoint.sh"]

--- a/infrastructure/Perforce/docker-compose.yml
+++ b/infrastructure/Perforce/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  perforce:
+    build: .
+    container_name: perforce
+    ports:
+      - "1666:1666"
+    volumes:
+      - ./data:/perforce-data
+    environment:
+      P4PORT: 1666
+      P4USER: admin
+      P4PASSWD: Passw0rd123!
+      P4ROOT: /perforce-data
+      P4DEPOTS: /perforce-data/depots
+      DEBIAN_FRONTEND: noninteractive

--- a/infrastructure/Perforce/entrypoint.sh
+++ b/infrastructure/Perforce/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Initialize Perforce server on first run
+if [ ! -f "$P4ROOT/db.have" ]; then
+    p4d -r "$P4ROOT" -p "$P4PORT" -d
+    sleep 3
+    if ! /usr/bin/p4 -p localhost:$P4PORT users | grep -q "^$P4USER "; then
+        /usr/bin/p4 -p localhost:$P4PORT user -f -i <<P4EOF
+User: $P4USER
+Type: super
+Email: admin@example.com
+FullName: Administrator
+P4EOF
+        echo -e "$P4PASSWD\n$P4PASSWD" | /usr/bin/p4 -p localhost:$P4PORT passwd $P4USER
+    fi
+    /usr/bin/p4 -p localhost:$P4PORT admin stop
+fi
+
+exec p4d -r "$P4ROOT" -p "$P4PORT" -d --foreground


### PR DESCRIPTION
## Summary
- add Dockerfile, entrypoint script, data folder and compose config under `infrastructure/Perforce`
- update README instructions to use the new docker-compose setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848eb226dc48326801423205a11878b