### PR TITLE
Fix Perforce container startup

### DIFF
--- a/docker/perforce/entrypoint.sh
+++ b/docker/perforce/entrypoint.sh
@@ -17,4 +17,4 @@ P4EOF
     /usr/local/bin/p4 -p localhost:$P4PORT admin stop
 fi
 
-exec p4d -r "$P4ROOT" -p "$P4PORT" -d --foreground
+exec p4d -r "$P4ROOT" -p "$P4PORT"

--- a/infrastructure/Perforce/entrypoint.sh
+++ b/infrastructure/Perforce/entrypoint.sh
@@ -17,4 +17,4 @@ P4EOF
     /usr/bin/p4 -p localhost:$P4PORT admin stop
 fi
 
-exec p4d -r "$P4ROOT" -p "$P4PORT" -d --foreground
+exec p4d -r "$P4ROOT" -p "$P4PORT"


### PR DESCRIPTION
## Summary
- remove `--foreground` from Perforce entrypoint scripts so p4d starts properly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848ed93651c83269b06494cc1c8eedd