### PR TITLE
Add Jira WebSocket event listener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ JIRA_URL=
 JIRA_USER=
 JIRA_TOKEN=
 JIRA_PROJECT=
+JIRA_WS_URL=
 
 # Version control settings
 # Set VCS_TYPE to "git" for GitHub or "p4" for Perforce

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The variables include:
 - For Perforce: `P4PORT`, `P4USER`, `P4TICKET`.
 - To provision infrastructure with Terraform, set `TERRAFORM_DIR` to the
   directory containing your Terraform configuration.
+- To listen for new bugs over a WebSocket, set `JIRA_WS_URL` to the
+  endpoint providing bug create events.
 
 
 Run the agent and the variables in `.env` will be loaded automatically:
@@ -40,6 +42,9 @@ Run the agent and the variables in `.env` will be loaded automatically:
 ```bash
 python -m ai_agent
 ```
+
+If `JIRA_WS_URL` is defined, the agent connects to that WebSocket and
+processes bugs as they are reported instead of fetching them from Jira.
 
 ## Terraform Infrastructure
 

--- a/ai_agent/__main__.py
+++ b/ai_agent/__main__.py
@@ -6,6 +6,7 @@ from .connectors.github import GitHubConnector
 from .analysis import CodeAnalyzer
 from .agent import BugTriageAgent
 from .terraform_infra import TerraformInfrastructure
+from .connectors.jira_ws import JiraWebSocketClient
 
 
 
@@ -44,9 +45,14 @@ def main():
         infra = TerraformInfrastructure(tf_dir)
         infra.apply()
 
-
     agent = BugTriageAgent(jira, vcs, analyzer)
-    agent.triage(project_key)
+
+    ws_url = os.environ.get("JIRA_WS_URL")
+    if ws_url:
+        ws = JiraWebSocketClient(ws_url)
+        ws.listen(agent.process_bug)
+    else:
+        agent.triage(project_key)
 
 
 if __name__ == "__main__":

--- a/ai_agent/agent.py
+++ b/ai_agent/agent.py
@@ -15,12 +15,16 @@ class BugTriageAgent:
     def triage(self, project_key: str):
         bugs = self.jira.get_open_bugs(project_key)
         for bug in bugs:
-            key = bug["key"]
-            summary = bug["fields"]["summary"]
-            files = self.find_related_files(bug)
-            fix = self.analyzer.analyze_bug(summary, files)
-            review_url = self.create_review(summary, fix)
-            print(f"Created review for {key}: {review_url}")
+            self.process_bug(bug)
+
+    def process_bug(self, bug) -> None:
+        """Run analysis and create a review for a single bug."""
+        key = bug["key"]
+        summary = bug["fields"]["summary"]
+        files = self.find_related_files(bug)
+        fix = self.analyzer.analyze_bug(summary, files)
+        review_url = self.create_review(summary, fix)
+        print(f"Created review for {key}: {review_url}")
 
     def find_related_files(self, bug) -> List[str]:
         # Placeholder: use bug data to locate affected files

--- a/ai_agent/connectors/__init__.py
+++ b/ai_agent/connectors/__init__.py
@@ -1,0 +1,11 @@
+from .github import GitHubConnector
+from .jira import JiraConnector
+from .perforce import PerforceConnector
+from .jira_ws import JiraWebSocketClient
+
+__all__ = [
+    "GitHubConnector",
+    "JiraConnector",
+    "PerforceConnector",
+    "JiraWebSocketClient",
+]

--- a/ai_agent/connectors/jira_ws.py
+++ b/ai_agent/connectors/jira_ws.py
@@ -1,0 +1,28 @@
+import json
+from typing import Callable
+
+from websocket import WebSocketApp
+
+
+class JiraWebSocketClient:
+    """Listen for Jira bug events over a WebSocket connection."""
+
+    def __init__(self, ws_url: str):
+        if not ws_url:
+            raise ValueError("JIRA_WS_URL must be provided")
+        self.ws_url = ws_url
+
+    def listen(self, on_bug: Callable[[dict], None]) -> None:
+        """Start listening and invoke *on_bug* for each received bug."""
+
+        def _on_message(ws, message: str):
+            try:
+                data = json.loads(message)
+            except json.JSONDecodeError:
+                return
+            issue = data.get("issue") or data
+            if issue:
+                on_bug(issue)
+
+        ws = WebSocketApp(self.ws_url, on_message=_on_message)
+        ws.run_forever()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 
 boto3
 python-dotenv
+websocket-client


### PR DESCRIPTION
## Summary
- support processing single bugs via `BugTriageAgent.process_bug`
- add Jira websocket client for live bug events
- switch to websocket mode when `JIRA_WS_URL` is set
- document the new variable and dependency
- expose websocket client in package exports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848f36221d88326899efd602f7c9f5e