### PR TITLE
Add configurable review platform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ JIRA_WS_URL=
 # Version control settings
 # Set VCS_TYPE to "git" for GitHub or "p4" for Perforce
 VCS_TYPE=git
+# Set REVIEW_PLATFORM to "github_pr" for GitHub Pull Requests or "swarm" for Swarm reviews
+REVIEW_PLATFORM=
 
 # GitHub settings
 GITHUB_REPO=

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This project provides a skeleton implementation for an AI-driven bug triage agen
 ## Features
 - **Jira Integration** – Retrieve open bugs from a Jira project using the REST API.
 - **Code Analysis** – Analyze bug descriptions and affected files to generate a suggested fix (placeholder logic).
-- **Version Control Support** – Connect to GitHub or Perforce and create pull requests or Swarm reviews.
+- **Version Control Support** – Connect to GitHub or Perforce and create GitHub
+  pull requests or Swarm reviews. The version control system is set with
+  `VCS_TYPE` and the review platform with `REVIEW_PLATFORM` (use `github_pr` for
+  GitHub Pull Requests or `swarm` for Swarm reviews).
 - **Extensibility** – Placeholder hooks for incorporating AI models and learning from reviewer feedback.
 
 ## Running the Agent
@@ -31,6 +34,9 @@ The variables include:
   Jira project keys are typically uppercase; any extra whitespace will be
   stripped automatically when querying issues.
 - `VCS_TYPE` – `git` for GitHub (default) or `p4` for Perforce.
+- `REVIEW_PLATFORM` – `github_pr` for GitHub Pull Requests or `swarm` for Swarm
+  reviews. If unset, it defaults to the typical review method for the selected
+  VCS type.
 - For GitHub: `GITHUB_REPO`, `GITHUB_TOKEN`.
 - For Perforce: `P4PORT`, `P4USER`, `P4TICKET`.
 - To provision infrastructure with Terraform, set `TERRAFORM_DIR` to the

--- a/ai_agent/__main__.py
+++ b/ai_agent/__main__.py
@@ -21,6 +21,7 @@ def main():
         raise SystemExit("JIRA_URL, JIRA_USER, JIRA_TOKEN and JIRA_PROJECT must be set")
 
     vcs_type = os.environ.get("VCS_TYPE", "git")
+    review_platform = os.environ.get("REVIEW_PLATFORM")
 
     jira = JiraConnector(jira_url, jira_user, jira_token)
     analyzer = CodeAnalyzer()
@@ -40,12 +41,15 @@ def main():
             raise SystemExit("P4PORT, P4USER and P4TICKET must be set for Perforce")
         vcs = PerforceConnector(p4port, p4user, p4ticket)
 
+    if not review_platform:
+        review_platform = "github_pr" if vcs_type == "git" else "swarm"
+
+    agent = BugTriageAgent(jira, vcs, analyzer, review_platform)
+
     tf_dir = os.environ.get("TERRAFORM_DIR")
     if tf_dir:
         infra = TerraformInfrastructure(tf_dir)
         infra.apply()
-
-    agent = BugTriageAgent(jira, vcs, analyzer)
 
     ws_url = os.environ.get("JIRA_WS_URL")
     if ws_url:


### PR DESCRIPTION
## Summary
- allow specifying review platform via `REVIEW_PLATFORM`
- wire new env var through the agent
- document new setting in README and `.env.example`
- clarify that `github_pr` selects GitHub Pull Requests

## Testing
- `python -m py_compile ai_agent/agent.py ai_agent/__main__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848fe978c648326b2efa5259afad66d