### PR TITLE
Add webhook server for Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ python -m ai_agent
 If `JIRA_WS_URL` is defined, the agent connects to that WebSocket and
 processes bugs as they are reported instead of fetching them from Jira.
 
+## Webhook Server
+
+To run a persistent server that handles Jira webhook events, start:
+
+```bash
+python -m ai_agent.webhook_server
+```
+
+Configure your Jira project to send issue created webhooks to the `/webhook`
+endpoint of this server. Incoming bug payloads are processed immediately by the
+agent.
+
 ## Terraform Infrastructure
 
 Infrastructure is created with Terraform using the

--- a/ai_agent/webhook_server.py
+++ b/ai_agent/webhook_server.py
@@ -1,0 +1,81 @@
+import os
+import json
+from typing import Optional
+
+from dotenv import load_dotenv
+from flask import Flask, request, jsonify
+
+from .connectors.jira import JiraConnector
+from .connectors.github import GitHubConnector
+from .connectors.perforce import PerforceConnector
+from .analysis import CodeAnalyzer
+from .agent import BugTriageAgent
+from .terraform_infra import TerraformInfrastructure
+
+
+app = Flask(__name__)
+agent: Optional[BugTriageAgent] = None
+
+
+def init_agent() -> BugTriageAgent:
+    """Initialize the bug triage agent from environment variables."""
+    load_dotenv()
+    jira_url = os.environ.get("JIRA_URL")
+    jira_user = os.environ.get("JIRA_USER")
+    jira_token = os.environ.get("JIRA_TOKEN")
+    if not all([jira_url, jira_user, jira_token]):
+        raise SystemExit("JIRA_URL, JIRA_USER and JIRA_TOKEN must be set")
+
+    vcs_type = os.environ.get("VCS_TYPE", "git")
+    review_platform = os.environ.get("REVIEW_PLATFORM")
+
+    jira = JiraConnector(jira_url, jira_user, jira_token)
+    analyzer = CodeAnalyzer()
+
+    if vcs_type == "git":
+        repo = os.environ.get("GITHUB_REPO")
+        gh_token = os.environ.get("GITHUB_TOKEN")
+        if not repo or not gh_token:
+            raise SystemExit("GITHUB_REPO and GITHUB_TOKEN must be set for GitHub")
+        vcs = GitHubConnector(repo, gh_token)
+    else:
+        p4port = os.environ.get("P4PORT")
+        p4user = os.environ.get("P4USER")
+        p4ticket = os.environ.get("P4TICKET")
+        if not all([p4port, p4user, p4ticket]):
+            raise SystemExit("P4PORT, P4USER and P4TICKET must be set for Perforce")
+        vcs = PerforceConnector(p4port, p4user, p4ticket)
+
+    if not review_platform:
+        review_platform = "github_pr" if vcs_type == "git" else "swarm"
+
+    return BugTriageAgent(jira, vcs, analyzer, review_platform)
+
+
+@app.route("/webhook", methods=["POST"])
+def webhook() -> tuple:
+    """Handle Jira webhook calls."""
+    payload = request.get_json(force=True)
+    issue = payload.get("issue") if isinstance(payload, dict) else None
+    issue = issue or payload
+    if issue:
+        agent.process_bug(issue)
+        return jsonify({"status": "processed"}), 200
+    return jsonify({"error": "no issue payload"}), 400
+
+
+def main() -> None:
+    global agent
+    agent = init_agent()
+
+    tf_dir = os.environ.get("TERRAFORM_DIR")
+    if tf_dir:
+        infra = TerraformInfrastructure(tf_dir)
+        infra.apply()
+
+    port = int(os.environ.get("PORT", 8000))
+    app.run(host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests
 boto3
 python-dotenv
 websocket-client
+
+flask


### PR DESCRIPTION
## Summary
- expose a simple Flask webhook server
- document how to run the server
- include flask in dependencies

## Testing
- `python -m py_compile ai_agent/webhook_server.py`
- `JIRA_URL=http://example.com JIRA_USER=user JIRA_TOKEN=token GITHUB_REPO=owner/repo GITHUB_TOKEN=gh-token JIRA_PROJECT=ABC PORT=9000 python -m ai_agent.webhook_server >/tmp/server.log 2>&1 & pid=$!; sleep 2; kill $pid` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68491bdbaae083269d602a32e703802d