### PR TITLE
Improve webhook handling and code analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project provides a skeleton implementation for an AI-driven bug triage agen
 
 ## Features
 - **Jira Integration** – Retrieve open bugs from a Jira project using the REST API.
-- **Code Analysis** – Analyze bug descriptions and affected files to generate a suggested fix (placeholder logic).
+- **Code Analysis** – Analyze bug titles and descriptions and locate affected files using the GitHub code search API to generate a suggested fix (placeholder logic).
 - **Version Control Support** – Connect to GitHub or Perforce and create GitHub
   pull requests or Swarm reviews. The version control system is set with
   `VCS_TYPE` and the review platform with `REVIEW_PLATFORM` (use `github_pr` for
@@ -66,8 +66,9 @@ python -m ai_agent.webhook_server
 ```
 
 Configure your Jira project to send "issue created" webhooks to the `/webhook`
-endpoint of this server. Only issues of type **Bug** are processed. Incoming
-payloads are handled immediately by the agent.
+endpoint of this server. The handler accepts `POST` (and optional `GET`) requests
+and only processes issues of type **Bug**. Incoming payloads are handled
+immediately by the agent.
 
 
 ## Terraform Infrastructure

--- a/ai_agent/analysis.py
+++ b/ai_agent/analysis.py
@@ -2,8 +2,9 @@ from typing import List, Dict
 
 
 class CodeAnalyzer:
-    def analyze_bug(self, bug_description: str, files: List[str]) -> Dict[str, str]:
-        """Analyze the code and return a suggested fix as a dictionary mapping file paths to patch text."""
-        # Placeholder for AI analysis logic
-        print(f"Analyzing bug: {bug_description} in {files}")
+    def analyze_bug(self, title: str, description: str, files: List[str]) -> Dict[str, str]:
+        """Analyze the bug title and description to suggest code fixes."""
+
+        bug_text = f"{title} {description}".strip()
+        print(f"Analyzing bug: {bug_text} in {files}")
         return {file: "# TODO: implement fix" for file in files}

--- a/ai_agent/connectors/github.py
+++ b/ai_agent/connectors/github.py
@@ -30,3 +30,20 @@ class GitHubConnector:
         response = requests.post(url, json=payload, headers=self.headers)
         response.raise_for_status()
         return response.json()
+
+    def search_code(self, keywords: list[str], max_results: int = 5) -> list[str]:
+        """Search the repository for files containing the given keywords."""
+
+        results: list[str] = []
+        for word in keywords:
+            query = f"{word} repo:{self.repo}"
+            url = "https://api.github.com/search/code"
+            resp = requests.get(url, params={"q": query}, headers=self.headers)
+            if resp.status_code != 200:
+                continue
+            data = resp.json()
+            for item in data.get("items", [])[:max_results]:
+                path = item.get("path")
+                if path and path not in results:
+                    results.append(path)
+        return results

--- a/ai_agent/webhook_server.py
+++ b/ai_agent/webhook_server.py
@@ -59,10 +59,19 @@ def init_agent() -> BugTriageAgent:
     return BugTriageAgent(jira, vcs, analyzer, review_platform)
 
 
-@app.route("/webhook", methods=["POST"])
+@app.route("/webhook", methods=["POST", "GET"])
 def webhook() -> tuple:
     """Handle Jira webhook calls for newly created bug issues."""
-    payload = request.get_json(force=True)
+    if request.method == "GET":
+        if "payload" in request.args:
+            try:
+                payload = json.loads(request.args["payload"])
+            except json.JSONDecodeError:
+                payload = {}
+        else:
+            payload = request.args.to_dict()
+    else:
+        payload = request.get_json(force=True)
     if not isinstance(payload, dict):
         return jsonify({"error": "invalid payload"}), 400
 


### PR DESCRIPTION
## Summary
- extend GitHub connector with code search helper
- update bug triage agent to analyze title and description
- discover related files via GitHub search
- allow GET requests for the Jira webhook endpoint
- document new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc4923fa08326b052368df2b2f180