### PR TITLE
Print new ticket data on receipt

### DIFF
--- a/ai_agent/connectors/jira_ws.py
+++ b/ai_agent/connectors/jira_ws.py
@@ -22,6 +22,8 @@ class JiraWebSocketClient:
                 return
             issue = data.get("issue") or data
             if issue:
+                # Debug output so we can verify incoming tickets during development
+                print(f"Received issue via WebSocket: {json.dumps(issue)}")
                 on_bug(issue)
 
         ws = WebSocketApp(self.ws_url, on_message=_on_message)

--- a/ai_agent/webhook_server.py
+++ b/ai_agent/webhook_server.py
@@ -88,6 +88,8 @@ def webhook() -> tuple:
             .lower()
         )
         if issuetype == "bug":
+            # Show the raw issue for debugging purposes when a ticket is created
+            print(f"Received new issue via webhook: {json.dumps(issue)}")
             agent.process_bug(issue)
             return jsonify({"status": "processed"}), 200
         return jsonify({"status": "ignored", "reason": "not a bug"}), 200


### PR DESCRIPTION
## Summary
- print issue contents when receiving a new bug over the Jira websocket
- print issue contents when receiving a new bug via the webhook server

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cc61f21288326870cb1ef3b0bfc21