### PR TITLE
Fix GitHub PR creation when branch has no commits

### DIFF
--- a/ai_agent/agent.py
+++ b/ai_agent/agent.py
@@ -49,6 +49,8 @@ class BugTriageAgent:
         ):
             branch = f"bugfix-{bug_key}".lower().replace(" ", "-")
             self.vcs.ensure_branch(branch, "main")
+            if fix:
+                self.vcs.commit_files(branch, fix, "Automated fix")
             github_pr = self.vcs.create_pull_request(
                 title=f"Fix: {summary}",
                 head=branch,


### PR DESCRIPTION
## Summary
- add utility to commit file changes via GitHub API
- update agent to commit suggested fixes before creating PRs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ccdf88afc8326a064004f1807cf2f