### PR TITLE
Add config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ First install the Python dependencies:
 pip install -r requirements.txt
 ```
 
-Configuration is handled via environment variables. Copy `.env.example` to
-`.env` and fill in the appropriate values:
+Configuration is handled via environment variables or an optional JSON config
+file. Copy `.env.example` to `.env` and fill in the appropriate values, or
+create `config.json` based on `config.example.json`:
 
 ```
 cp .env.example .env
 # edit .env with your editor of choice
+
+# or provide settings in config.json
+cp config.example.json config.json
 ```
 
 The variables include:
@@ -45,6 +49,10 @@ The variables include:
   endpoint providing bug create events.
 - `PORT` and `HOST` allow configuring the webhook server's port and host.
 - `HF_MODEL` specifies the Hugging Face model used for code analysis (defaults to `gpt2`).
+
+All of these keys may also be provided in a `config.json` file using the same
+names but in lowercase (e.g. `jira_url`, `github_repo`). Environment variables
+override values from the config file if both are present.
 
 
 Run the agent and the variables in `.env` will be loaded automatically:

--- a/ai_agent/__main__.py
+++ b/ai_agent/__main__.py
@@ -7,38 +7,46 @@ from .analysis import CodeAnalyzer
 from .agent import BugTriageAgent
 from .terraform_infra import TerraformInfrastructure
 from .connectors.jira_ws import JiraWebSocketClient
+from .config import load_config
 
 
 
 def main():
     load_dotenv()
-    jira_url = os.environ.get("JIRA_URL")
-    jira_user = os.environ.get("JIRA_USER")
-    jira_token = os.environ.get("JIRA_TOKEN")
-    project_key = os.environ.get("JIRA_PROJECT")
+    config = load_config(os.environ.get("CONFIG_FILE"))
+    jira_url = os.environ.get("JIRA_URL") or config.get("jira_url")
+    jira_user = os.environ.get("JIRA_USER") or config.get("jira_user")
+    jira_token = os.environ.get("JIRA_TOKEN") or config.get("jira_token")
+    project_key = os.environ.get("JIRA_PROJECT") or config.get("jira_project")
 
     if not all([jira_url, jira_user, jira_token, project_key]):
-        raise SystemExit("JIRA_URL, JIRA_USER, JIRA_TOKEN and JIRA_PROJECT must be set")
+        raise SystemExit(
+            "JIRA_URL, JIRA_USER, JIRA_TOKEN and JIRA_PROJECT must be set"
+        )
 
-    vcs_type = os.environ.get("VCS_TYPE", "git")
-    review_platform = os.environ.get("REVIEW_PLATFORM")
+    vcs_type = os.environ.get("VCS_TYPE") or config.get("vcs_type", "git")
+    review_platform = os.environ.get("REVIEW_PLATFORM") or config.get("review_platform")
 
     jira = JiraConnector(jira_url, jira_user, jira_token)
     analyzer = CodeAnalyzer()
 
     if vcs_type == "git":
-        repo = os.environ.get("GITHUB_REPO")
-        gh_token = os.environ.get("GITHUB_TOKEN")
+        repo = os.environ.get("GITHUB_REPO") or config.get("github_repo")
+        gh_token = os.environ.get("GITHUB_TOKEN") or config.get("github_token")
         if not repo or not gh_token:
-            raise SystemExit("GITHUB_REPO and GITHUB_TOKEN must be set for GitHub")
+            raise SystemExit(
+                "GITHUB_REPO and GITHUB_TOKEN must be set for GitHub"
+            )
 
         vcs = GitHubConnector(repo, gh_token)
     else:
-        p4port = os.environ.get("P4PORT")
-        p4user = os.environ.get("P4USER")
-        p4ticket = os.environ.get("P4TICKET")
+        p4port = os.environ.get("P4PORT") or config.get("p4port")
+        p4user = os.environ.get("P4USER") or config.get("p4user")
+        p4ticket = os.environ.get("P4TICKET") or config.get("p4ticket")
         if not all([p4port, p4user, p4ticket]):
-            raise SystemExit("P4PORT, P4USER and P4TICKET must be set for Perforce")
+            raise SystemExit(
+                "P4PORT, P4USER and P4TICKET must be set for Perforce"
+            )
         vcs = PerforceConnector(p4port, p4user, p4ticket)
 
     if not review_platform:

--- a/ai_agent/config.py
+++ b/ai_agent/config.py
@@ -1,0 +1,22 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_config(path: str | None = None) -> Dict[str, Any]:
+    """Load configuration from *path* if it exists.
+
+    The file is expected to contain JSON with keys matching the lowercase
+    environment variable names used by the application. If the file cannot be
+    read or parsed, an empty dictionary is returned.
+    """
+    file_path = Path(path or "config.json")
+    if not file_path.is_file():
+        return {}
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        # Fail silently and just use environment variables
+        return {}

--- a/ai_agent/webhook_server.py
+++ b/ai_agent/webhook_server.py
@@ -18,6 +18,7 @@ from .connectors.perforce import PerforceConnector
 from .analysis import CodeAnalyzer
 from .agent import BugTriageAgent
 from .terraform_infra import TerraformInfrastructure
+from .config import load_config
 
 
 app = Flask(__name__)
@@ -27,28 +28,29 @@ agent: Optional[BugTriageAgent] = None
 def init_agent() -> BugTriageAgent:
     """Initialize the bug triage agent from environment variables."""
     load_dotenv()
-    jira_url = os.environ.get("JIRA_URL")
-    jira_user = os.environ.get("JIRA_USER")
-    jira_token = os.environ.get("JIRA_TOKEN")
+    config = load_config(os.environ.get("CONFIG_FILE"))
+    jira_url = os.environ.get("JIRA_URL") or config.get("jira_url")
+    jira_user = os.environ.get("JIRA_USER") or config.get("jira_user")
+    jira_token = os.environ.get("JIRA_TOKEN") or config.get("jira_token")
     if not all([jira_url, jira_user, jira_token]):
         raise SystemExit("JIRA_URL, JIRA_USER and JIRA_TOKEN must be set")
 
-    vcs_type = os.environ.get("VCS_TYPE", "git")
-    review_platform = os.environ.get("REVIEW_PLATFORM")
+    vcs_type = os.environ.get("VCS_TYPE") or config.get("vcs_type", "git")
+    review_platform = os.environ.get("REVIEW_PLATFORM") or config.get("review_platform")
 
     jira = JiraConnector(jira_url, jira_user, jira_token)
     analyzer = CodeAnalyzer()
 
     if vcs_type == "git":
-        repo = os.environ.get("GITHUB_REPO")
-        gh_token = os.environ.get("GITHUB_TOKEN")
+        repo = os.environ.get("GITHUB_REPO") or config.get("github_repo")
+        gh_token = os.environ.get("GITHUB_TOKEN") or config.get("github_token")
         if not repo or not gh_token:
             raise SystemExit("GITHUB_REPO and GITHUB_TOKEN must be set for GitHub")
         vcs = GitHubConnector(repo, gh_token)
     else:
-        p4port = os.environ.get("P4PORT")
-        p4user = os.environ.get("P4USER")
-        p4ticket = os.environ.get("P4TICKET")
+        p4port = os.environ.get("P4PORT") or config.get("p4port")
+        p4user = os.environ.get("P4USER") or config.get("p4user")
+        p4ticket = os.environ.get("P4TICKET") or config.get("p4ticket")
         if not all([p4port, p4user, p4ticket]):
             raise SystemExit("P4PORT, P4USER and P4TICKET must be set for Perforce")
         vcs = PerforceConnector(p4port, p4user, p4ticket)

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,13 @@
+{
+    "jira_url": "https://jira.example.com",
+    "jira_user": "user@example.com",
+    "jira_token": "TOKEN",
+    "jira_project": "BUGS",
+    "vcs_type": "git",
+    "review_platform": "github_pr",
+    "github_repo": "owner/repo",
+    "github_token": "TOKEN",
+    "p4port": "",
+    "p4user": "",
+    "p4ticket": ""
+}


### PR DESCRIPTION
## Summary
- support loading config.json to control VCS and review platform
- add example config file
- document config.json usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cd20535d08326b01e09b4ebe40f27