### PR TITLE
Add basic learning memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ p4 -p localhost:1666 passwd admin
 
 The container downloads the `p4d` binary from Perforce. If the download fails, ensure the URL in the Dockerfile matches an available release or update `P4D_VERSION` to the desired version.
 
+## Learning from Tickets and Code
+
+The agent can build a small memory of past bug tickets and their fixes using open source models.
+Steps to enable this feature:
+
+1. Install the additional requirement `numpy` listed in `requirements.txt`.
+2. Set `MEMORY_FILE` to the path where the agent should store its knowledge (defaults to `memory.json`).
+3. Optionally set `MEMORY_MODEL` to a Hugging Face model for embedding bug text (defaults to `distilbert-base-uncased`).
+4. Run the agent as usual. After each bug is processed, the ticket text and generated patch are stored.
+5. When a new ticket arrives, the analyzer searches the memory for similar issues and reuses the stored solution when one is found.
+
+This simple memory grows over time and helps the agent suggest fixes based on previous reviews.
+
 ## Notes
 This codebase provides a starting point only. Actual integration with Jira, Perforce, GitHub, and AWS requires additional configuration and authentication setup. The code analysis and learning components are simplified placeholders.
 

--- a/ai_agent/__main__.py
+++ b/ai_agent/__main__.py
@@ -4,6 +4,7 @@ from .connectors.jira import JiraConnector
 from .connectors.perforce import PerforceConnector
 from .connectors.github import GitHubConnector
 from .analysis import CodeAnalyzer
+from .memory import SimpleMemory
 from .agent import BugTriageAgent
 from .terraform_infra import TerraformInfrastructure
 from .connectors.jira_ws import JiraWebSocketClient
@@ -24,7 +25,10 @@ def main():
     review_platform = os.environ.get("REVIEW_PLATFORM")
 
     jira = JiraConnector(jira_url, jira_user, jira_token)
-    analyzer = CodeAnalyzer()
+
+    memory_file = os.environ.get("MEMORY_FILE", "memory.json")
+    memory = SimpleMemory(path=memory_file)
+    analyzer = CodeAnalyzer(memory=memory)
 
     if vcs_type == "git":
         repo = os.environ.get("GITHUB_REPO")
@@ -61,3 +65,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/ai_agent/agent.py
+++ b/ai_agent/agent.py
@@ -29,6 +29,7 @@ class BugTriageAgent:
         files = self.find_related_files(summary, description)
         fix = self.analyzer.analyze_bug(summary, description, files)
         review_url = self.create_review(key, summary, fix)
+        self.analyzer.remember(summary, description, fix)
         print(f"Created review for {key}: {review_url}")
 
     def find_related_files(self, title: str, description: str) -> List[str]:

--- a/ai_agent/analysis.py
+++ b/ai_agent/analysis.py
@@ -3,21 +3,28 @@ from pathlib import Path
 from typing import List, Dict
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
+from .memory import SimpleMemory
 
 
 class CodeAnalyzer:
-    """Analyze bug reports with an open source language model."""
+    """Analyze bug reports with an open source language model and optional memory."""
 
-    def __init__(self, model_name: str | None = None) -> None:
+    def __init__(self, model_name: str | None = None, memory: SimpleMemory | None = None) -> None:
         self.model_name = model_name or os.environ.get("HF_MODEL", "gpt2")
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         self.model = AutoModelForCausalLM.from_pretrained(self.model_name)
+        self.memory = memory
 
     def analyze_bug(self, title: str, description: str, files: List[str]) -> Dict[str, str]:
         """Use an LLM to suggest code fixes for the given files."""
 
         bug_text = f"Bug Title: {title}\nDescription: {description}\n".strip()
         fixes: Dict[str, str] = {}
+        if self.memory:
+            # Attempt to reuse existing solutions
+            past = self.memory.search(bug_text, top_k=1)
+            if past:
+                return past[0]["solution"]
         for file in files:
             try:
                 code = Path(file).read_text()
@@ -34,4 +41,13 @@ class CodeAnalyzer:
             text = self.tokenizer.decode(output_ids[0], skip_special_tokens=True)
             patch = text.split("# Suggested patch:")[-1].strip()
             fixes[file] = patch
+        if self.memory:
+            self.memory.add(bug_text, fixes)
         return fixes
+
+    def remember(self, title: str, description: str, fix: Dict[str, str]) -> None:
+        """Persist the bug description and resulting fix."""
+        if self.memory:
+            bug_text = f"Bug Title: {title}\nDescription: {description}\n".strip()
+            self.memory.add(bug_text, fix)
+

--- a/ai_agent/memory.py
+++ b/ai_agent/memory.py
@@ -1,0 +1,54 @@
+import json
+import os
+from pathlib import Path
+from typing import List, Dict, Any
+
+import torch
+from transformers import AutoTokenizer, AutoModel
+import numpy as np
+
+
+class SimpleMemory:
+    """Store bug reports and solutions as vector embeddings."""
+
+    def __init__(self, model_name: str | None = None, path: str | Path = "memory.json") -> None:
+        self.model_name = model_name or os.environ.get("MEMORY_MODEL", "distilbert-base-uncased")
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self.model = AutoModel.from_pretrained(self.model_name)
+        self.path = Path(path)
+        self.entries: List[Dict[str, Any]] = []
+        if self.path.is_file():
+            try:
+                self.entries = json.loads(self.path.read_text())
+            except json.JSONDecodeError:
+                self.entries = []
+
+    def _embed(self, text: str) -> List[float]:
+        inputs = self.tokenizer(text, return_tensors="pt", truncation=True)
+        with torch.no_grad():
+            outputs = self.model(**inputs).last_hidden_state.mean(dim=1)
+        return outputs.squeeze().tolist()
+
+    def save(self) -> None:
+        self.path.write_text(json.dumps(self.entries))
+
+    def add(self, text: str, solution: Dict[str, str]) -> None:
+        vec = self._embed(text)
+        self.entries.append({"text": text, "solution": solution, "embedding": vec})
+        self.save()
+
+    def search(self, text: str, top_k: int = 3) -> List[Dict[str, Any]]:
+        if not self.entries:
+            return []
+        query = np.array(self._embed(text))
+
+        def similarity(v: List[float]) -> float:
+            v = np.array(v)
+            denom = np.linalg.norm(query) * np.linalg.norm(v)
+            if denom == 0:
+                return 0.0
+            return float(np.dot(query, v) / denom)
+
+        scored = [(similarity(e["embedding"]), e) for e in self.entries]
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [e for _, e in scored[:top_k]]

--- a/ai_agent/webhook_server.py
+++ b/ai_agent/webhook_server.py
@@ -16,6 +16,7 @@ from .connectors.jira import JiraConnector
 from .connectors.github import GitHubConnector
 from .connectors.perforce import PerforceConnector
 from .analysis import CodeAnalyzer
+from .memory import SimpleMemory
 from .agent import BugTriageAgent
 from .terraform_infra import TerraformInfrastructure
 
@@ -37,7 +38,10 @@ def init_agent() -> BugTriageAgent:
     review_platform = os.environ.get("REVIEW_PLATFORM")
 
     jira = JiraConnector(jira_url, jira_user, jira_token)
-    analyzer = CodeAnalyzer()
+
+    memory_file = os.environ.get("MEMORY_FILE", "memory.json")
+    memory = SimpleMemory(path=memory_file)
+    analyzer = CodeAnalyzer(memory=memory)
 
     if vcs_type == "git":
         repo = os.environ.get("GITHUB_REPO")
@@ -114,3 +118,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ websocket-client
 flask
 transformers
 torch
+numpy


### PR DESCRIPTION
## Summary
- implement `SimpleMemory` to store embeddings and previous fixes
- use the memory in `CodeAnalyzer`
- store bug/fix pairs from `BugTriageAgent`
- expose memory handling in command line entry point and webhook server
- document memory setup and add numpy requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cd3203b6083268d089a1163a057ef