### PR TITLE
Add microservice scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,12 @@ This simple memory grows over time and helps the agent suggest fixes based on pr
 ## Notes
 This codebase provides a starting point only. Actual integration with Jira, Perforce, GitHub, and AWS requires additional configuration and authentication setup. The code analysis and learning components are simplified placeholders.
 
+
+## Microservices
+
+Two lightweight services demonstrate how the agent's responsibilities can be split into dedicated components:
+
+- `code_learner_service` – stores code snippets so other tools can reference them when analyzing bugs.
+- `bug_analyzer_service` – wraps `CodeAnalyzer` and exposes endpoints for bug analysis and learning from reviewer feedback.
+
+Run each service with `python service.py` inside its directory. The code learner listens on port `5001` and the bug analyzer on port `5002`.

--- a/bug_analyzer_service/README.md
+++ b/bug_analyzer_service/README.md
@@ -1,0 +1,8 @@
+# Bug Analyzer + Learner Service
+
+This service wraps the existing `CodeAnalyzer` from the main project and exposes simple HTTP endpoints:
+
+- `POST /analyze` – accepts `title`, `description`, and optional `files` to return suggested fixes.
+- `POST /remember` – store a provided fix so that future analysis can reuse it.
+
+Start the server with `python service.py`. It listens on port `5002`.

--- a/bug_analyzer_service/__init__.py
+++ b/bug_analyzer_service/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the bug analyzer and learner microservice."""

--- a/bug_analyzer_service/service.py
+++ b/bug_analyzer_service/service.py
@@ -1,0 +1,36 @@
+"""Bug analyzer and learning microservice."""
+
+from flask import Flask, request, jsonify
+
+from ai_agent.analysis import CodeAnalyzer
+from ai_agent.memory import SimpleMemory
+
+app = Flask(__name__)
+memory = SimpleMemory(path="memory.json")
+analyzer = CodeAnalyzer(memory=memory)
+
+
+@app.route("/analyze", methods=["POST"])
+def analyze_bug():
+    """Return suggested code fixes for a bug report."""
+    payload = request.get_json(force=True)
+    title = payload.get("title", "")
+    description = payload.get("description", "")
+    files = payload.get("files", [])
+    fixes = analyzer.analyze_bug(title, description, files)
+    return jsonify(fixes)
+
+
+@app.route("/remember", methods=["POST"])
+def remember_fix():
+    """Remember a bug fix for future reuse."""
+    payload = request.get_json(force=True)
+    title = payload.get("title", "")
+    description = payload.get("description", "")
+    fix = payload.get("fix", {})
+    analyzer.remember(title, description, fix)
+    return jsonify({"status": "stored"})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5002)

--- a/code_learner_service/README.md
+++ b/code_learner_service/README.md
@@ -1,0 +1,8 @@
+# Code Learner Service
+
+This microservice stores small snippets of source code for later reference. It exposes two HTTP endpoints using Flask:
+
+- `POST /learn` – submit a JSON payload with `file` and `content` keys to store code content.
+- `GET /memory` – returns all stored code snippets as JSON.
+
+Run the service directly with `python service.py`. It listens on port `5001` by default.

--- a/code_learner_service/__init__.py
+++ b/code_learner_service/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the code learner microservice."""

--- a/code_learner_service/service.py
+++ b/code_learner_service/service.py
@@ -1,0 +1,28 @@
+"""Simple microservice for learning code context."""
+
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+code_memory: dict[str, str] = {}
+
+
+@app.route("/learn", methods=["POST"])
+def learn_code():
+    """Store code content keyed by file name."""
+    payload = request.get_json(force=True)
+    filename = payload.get("file")
+    content = payload.get("content", "")
+    if not filename:
+        return jsonify({"error": "file required"}), 400
+    code_memory[filename] = content
+    return jsonify({"status": "stored", "file": filename}), 200
+
+
+@app.route("/memory", methods=["GET"])
+def get_memory():
+    """Return known code snippets."""
+    return jsonify(code_memory)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5001)


### PR DESCRIPTION
## Summary
- add `code_learner_service` for storing and serving code snippets
- add `bug_analyzer_service` that exposes `CodeAnalyzer` via HTTP
- mention the new microservices in the main README

## Testing
- `python -m py_compile code_learner_service/service.py bug_analyzer_service/service.py`

------
https://chatgpt.com/codex/tasks/task_e_684cd643dfe48326be2988ceed0a4a5d