### PR TITLE
Document separate service ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,17 @@ Two lightweight services demonstrate how the agent's responsibilities can be spl
 - `code_learner_service` – stores code snippets so other tools can reference them when analyzing bugs.
 - `bug_analyzer_service` – wraps `CodeAnalyzer` and exposes endpoints for bug analysis and learning from reviewer feedback.
 
-Run each service with `python service.py` inside its directory. The code learner listens on port `5001` and the bug analyzer on port `5002`.
+Run each service with `python service.py` in its directory. By default the code
+learner listens on port `5001` and the bug analyzer on port `5002`.
+
+To run the services simultaneously use separate terminals:
+
+```bash
+# Terminal 1: code learner
+cd code_learner_service
+python service.py               # or PORT=6001 python service.py
+
+# Terminal 2: bug analyzer
+cd bug_analyzer_service
+python service.py               # or PORT=6002 python service.py
+```

--- a/bug_analyzer_service/service.py
+++ b/bug_analyzer_service/service.py
@@ -1,5 +1,6 @@
 """Bug analyzer and learning microservice."""
 
+import os
 from flask import Flask, request, jsonify
 
 from ai_agent.analysis import CodeAnalyzer
@@ -33,4 +34,5 @@ def remember_fix():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5002)
+    port = int(os.getenv("PORT", 5002))
+    app.run(host="0.0.0.0", port=port)

--- a/code_learner_service/service.py
+++ b/code_learner_service/service.py
@@ -1,5 +1,6 @@
 """Simple microservice for learning code context."""
 
+import os
 from flask import Flask, request, jsonify
 
 app = Flask(__name__)
@@ -25,4 +26,5 @@ def get_memory():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5001)
+    port = int(os.getenv("PORT", 5001))
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- allow microservices to configure their ports via the `PORT` environment variable
- clarify README instructions for running each service in its own terminal with different ports

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684cd86f1c08832694d70c09ef959a43