### PR TITLE
Fix system diagram mermaid syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,25 @@ python service.py               # or PORT=6001 python service.py
 cd bug_analyzer_service
 python service.py               # or PORT=6002 python service.py
 ```
+
+## System Design
+The following diagram illustrates the overall architecture of the bug triage system.
+
+```mermaid
+graph TD
+    Jira[Jira]
+    Webhook[Webhook Server]
+    Agent[AI Bug Triage Agent]
+    Analyzer[Bug Analyzer Service]
+    Learner[Code Learner Service]
+    VCS["VCS (GitHub/Perforce)"]
+    Review[Review Platform]
+    Infra[Terraform Infrastructure]
+    Jira --> Webhook
+    Webhook --> Agent
+    Agent --> Analyzer
+    Agent --> Learner
+    Agent --> VCS
+    VCS --> Review
+    Agent --> Infra
+```


### PR DESCRIPTION
## Summary
- quote VCS label in mermaid diagram to avoid parse error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0c1dd63883268d948438c08e5f29