### PR TITLE
Integrate vector index and StarCoder in code learner

### DIFF
--- a/code_learner_service/README.md
+++ b/code_learner_service/README.md
@@ -1,8 +1,13 @@
 # Code Learner Service
 
-This microservice stores small snippets of source code for later reference. It exposes two HTTP endpoints using Flask:
+This microservice stores small snippets of source code and builds a vector index
+using **LlamaIndex** with a **FAISS** backend. It can also generate code using
+a local StarCoder model. The service exposes several HTTP endpoints:
 
-- `POST /learn` – submit a JSON payload with `file` and `content` keys to store code content.
-- `GET /memory` – returns all stored code snippets as JSON.
+- `POST /learn` – store a snippet with `file` and `content` keys.
+- `GET /memory` – return all stored snippets.
+- `POST /query` – search the FAISS index with `query` and return matching files.
+- `POST /generate` – provide a `prompt` to get a StarCoder completion.
 
-Run the service directly with `python service.py`. It listens on port `5001` by default.
+Run the service directly with `python service.py`. It listens on port `5001` by
+default.

--- a/code_learner_service/service.py
+++ b/code_learner_service/service.py
@@ -1,10 +1,37 @@
-"""Simple microservice for learning code context."""
+"""Microservice for learning and querying code snippets."""
 
 import os
+from typing import Any
+
 from flask import Flask, request, jsonify
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from .vector_index import CodeVectorIndex
+
 
 app = Flask(__name__)
 code_memory: dict[str, str] = {}
+vector_index = CodeVectorIndex()
+
+MODEL_NAME = os.getenv("CODE_MODEL", "bigcode/starcoderbase-1b")
+tokenizer: AutoTokenizer | None = None
+model: AutoModelForCausalLM | None = None
+
+
+def _load_model() -> None:
+    global tokenizer, model
+    if tokenizer is None or model is None:
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+        model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+
+
+def generate_code(prompt: str, max_new_tokens: int = 64) -> str:
+    """Generate code completion using StarCoder (or compatible) model."""
+    _load_model()
+    assert tokenizer is not None and model is not None
+    inputs = tokenizer(prompt, return_tensors="pt")
+    outputs = model.generate(**inputs, max_new_tokens=max_new_tokens)
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
 
 
 @app.route("/learn", methods=["POST"])
@@ -16,6 +43,7 @@ def learn_code():
     if not filename:
         return jsonify({"error": "file required"}), 400
     code_memory[filename] = content
+    vector_index.add_code(filename, content)
     return jsonify({"status": "stored", "file": filename}), 200
 
 
@@ -23,6 +51,24 @@ def learn_code():
 def get_memory():
     """Return known code snippets."""
     return jsonify(code_memory)
+
+
+@app.route("/query", methods=["POST"])
+def query_code() -> Any:
+    """Search indexed code snippets for a text query."""
+    payload = request.get_json(force=True)
+    query = payload.get("query", "")
+    files = vector_index.query(query)
+    return jsonify({"files": files})
+
+
+@app.route("/generate", methods=["POST"])
+def generate() -> Any:
+    """Generate code with the selected model."""
+    payload = request.get_json(force=True)
+    prompt = payload.get("prompt", "")
+    result = generate_code(prompt)
+    return jsonify({"completion": result})
 
 
 if __name__ == "__main__":

--- a/code_learner_service/vector_index.py
+++ b/code_learner_service/vector_index.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from llama_index import Document, ServiceContext, StorageContext, VectorStoreIndex
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from llama_index.vector_stores.faiss import FaissVectorStore
+
+
+class CodeVectorIndex:
+    """Manage FAISS-based vector index of code snippets."""
+
+    def __init__(self, persist_dir: str = "index_data", model_name: str = "Salesforce/codet5p-110m") -> None:
+        self.persist_dir = Path(persist_dir)
+        self.persist_dir.mkdir(parents=True, exist_ok=True)
+        self.embed_model = HuggingFaceEmbedding(model_name=model_name)
+
+        index_file = self.persist_dir / "faiss.index"
+        if index_file.exists():
+            self.vector_store = FaissVectorStore.from_persist_dir(persist_dir)
+            storage_context = StorageContext.from_defaults(vector_store=self.vector_store)
+            self.index = VectorStoreIndex.load_from_persist_dir(
+                persist_dir, service_context=ServiceContext.from_defaults(embed_model=self.embed_model), storage_context=storage_context
+            )
+        else:
+            self.vector_store = FaissVectorStore(dim=self.embed_model.embedding_size)
+            storage_context = StorageContext.from_defaults(vector_store=self.vector_store)
+            self.index = VectorStoreIndex(
+                [], service_context=ServiceContext.from_defaults(embed_model=self.embed_model), storage_context=storage_context
+            )
+            self.index.storage_context.persist(persist_dir)
+
+    def add_code(self, filename: str, content: str) -> None:
+        doc = Document(text=content, metadata={"file": filename})
+        self.index.insert(doc)
+        self.index.storage_context.persist(self.persist_dir)
+
+    def query(self, text: str, top_k: int = 3) -> List[str]:
+        query_engine = self.index.as_query_engine(similarity_top_k=top_k)
+        response = query_engine.query(text)
+        return [node.metadata.get("file", "") for node in response.source_nodes]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ flask
 transformers
 torch
 numpy
+llama-index
+faiss-cpu
+gpt4all


### PR DESCRIPTION
## Summary
- extend Code Learner Service to build a FAISS-backed LlamaIndex and provide query & generate endpoints
- load StarCoder model for code generation
- document new API usage
- add dependencies for llama-index, faiss-cpu and gpt4all

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e16cbc3d88326a27f6590f87789ab